### PR TITLE
Update markup for browser compatibility and fix accessibility issue

### DIFF
--- a/app/views/pictures/_form.html.erb
+++ b/app/views/pictures/_form.html.erb
@@ -13,29 +13,32 @@
 
   <fieldset class="form-group row">
     <legend class="col">Enter things here</legend>
+      <div class="col">
 
-    <div class="form-group col">
-      <%= form.label :caption %>
-      <%= form.text_field :caption, id: :picture_caption, class: 'form-control' %>
-      <small id="captionHelp" class="form-text text-muted">The caption on the homepage</small>
-    </div>
+      <div class="form-group">
+        <%= form.label :caption %>
+        <%= form.text_field :caption, id: :picture_caption, class: 'form-control' %>
+        <small id="captionHelp" class="form-text text-muted">The caption on the homepage</small>
+      </div>
 
-    <div class="form-group col">
-      <%= form.label :image_title %>
-      <%= form.text_field :image_title, id: :picture_image_title, class: 'form-control' %>
-      <small id="titleHelp" class="form-text text-muted">The title on the image page</small>
-    </div>
+      <div class="form-group">
+        <%= form.label :image_title %>
+        <%= form.text_field :image_title, id: :picture_image_title, class: 'form-control' %>
+        <small id="titleHelp" class="form-text text-muted">The title on the image page</small>
+      </div>
 
-    <div class="form-group col">
-      <%= form.label :description %>
-      <%= form.text_area :description, id: :picture_description, class: 'form-control', rows: 10 %>
-      <small id="descriptionHelp" class="form-text text-muted">The description on the image page</small>
-    </div>
+      <div class="form-group">
+        <%= form.label :description %>
+        <%= form.text_area :description, id: :picture_description, class: 'form-control', rows: 10 %>
+        <small id="descriptionHelp" class="form-text text-muted">The description on the image page</small>
+      </div>
 
-    <div class="form-group col">
-      <%= form.label :alt %>
-      <%= form.text_field :alt, id: :picture_alt, class: 'form-control' %>
-      <small id="altHelp" class="form-text text-muted">The alt text for the image</small>
+      <div class="form-group">
+        <%= form.label :alt %>
+        <%= form.text_field :alt, id: :picture_alt, class: 'form-control' %>
+        <small id="altHelp" class="form-text text-muted">The alt text for the image</small>
+      </div>
+
     </div>
   </fieldset>
 
@@ -47,48 +50,51 @@
 
   <fieldset class="form-group row hidden">
     <legend class="col">You can probably ignore these fields</legend>
+    <div class="col">
 
-    <div class="form-group col">
-      <%= form.label :user_id, 'Photographer' %>
-      <%- if current_user.admin? %>
-        <%= form.collection_select :user_id,
-                                 @users,
-                                 :id,
-                                 :fullname,
-                                 { prompt: true },
-                                 { id: :picture_user_id } %>
-      <%- else %>
-        <%= form.collection_select :user_id,
+      <div class="form-group">
+        <%= form.label :user_id, 'Photographer' %>
+        <%- if current_user.admin? %>
+          <%= form.collection_select :user_id,
                                    @users,
                                    :id,
                                    :fullname,
                                    { prompt: true },
-                                   { id: :picture_user_id,
-                                     disabled: true
-                                   } %>
-       <%- end %>
-    </div>
+                                   { id: :picture_user_id } %>
+        <%- else %>
+          <%= form.collection_select :user_id,
+                                     @users,
+                                     :id,
+                                     :fullname,
+                                     { prompt: true },
+                                     { id: :picture_user_id,
+                                       disabled: true
+                                     } %>
+         <%- end %>
+      </div>
 
-    <div class="form-group col">
-      <%= form.label :month %>
-      <%= form.select :month,
-                      Date::MONTHNAMES.compact.zip([*1..12]).to_h,
-                      {},
-                      { id: :picture_month, class: 'custom-select' } %>
-    </div>
+      <div class="form-group">
+        <%= form.label :month %>
+        <%= form.select :month,
+                        Date::MONTHNAMES.compact.zip([*1..12]).to_h,
+                        {},
+                        { id: :picture_month, class: 'custom-select' } %>
+      </div>
 
-    <div class="form-group col">
-      <%= form.label :year %>
-      <%= form.select :year,
-                      [Date.current.year - 1, Date.current.year, Date.current.year + 1],
-                      {},
-                      { id: :picture_year, class: 'custom-select' } %>
+      <div class="form-group">
+        <%= form.label :year %>
+        <%= form.select :year,
+                        [Date.current.year - 1, Date.current.year, Date.current.year + 1],
+                        {},
+                        { id: :picture_year, class: 'custom-select' } %>
+      </div>
+
     </div>
   </fieldset>
 
   <div class="actions row">
     <div class="col">
-      <%= form.submit 'Behold my image', class: 'btn btn-primary' %>
+      <%= form.submit 'Save my image', class: 'btn btn-primary' %>
     </div>
   </div>
 <% end %>

--- a/app/views/pictures/_form.html.erb
+++ b/app/views/pictures/_form.html.erb
@@ -17,25 +17,25 @@
 
       <div class="form-group">
         <%= form.label :caption %>
-        <%= form.text_field :caption, id: :picture_caption, class: 'form-control' %>
+        <%= form.text_field :caption, class: 'form-control' %>
         <small id="captionHelp" class="form-text text-muted">The caption on the homepage</small>
       </div>
 
       <div class="form-group">
         <%= form.label :image_title %>
-        <%= form.text_field :image_title, id: :picture_image_title, class: 'form-control' %>
+        <%= form.text_field :image_title, class: 'form-control' %>
         <small id="titleHelp" class="form-text text-muted">The title on the image page</small>
       </div>
 
       <div class="form-group">
         <%= form.label :description %>
-        <%= form.text_area :description, id: :picture_description, class: 'form-control', rows: 10 %>
+        <%= form.text_area :description, class: 'form-control', rows: 10 %>
         <small id="descriptionHelp" class="form-text text-muted">The description on the image page</small>
       </div>
 
       <div class="form-group">
         <%= form.label :alt %>
-        <%= form.text_field :alt, id: :picture_alt, class: 'form-control' %>
+        <%= form.text_field :alt, class: 'form-control' %>
         <small id="altHelp" class="form-text text-muted">The alt text for the image</small>
       </div>
 
@@ -78,7 +78,7 @@
         <%= form.select :month,
                         Date::MONTHNAMES.compact.zip([*1..12]).to_h,
                         {},
-                        { id: :picture_month, class: 'custom-select' } %>
+                        { class: 'custom-select' } %>
       </div>
 
       <div class="form-group">
@@ -86,7 +86,7 @@
         <%= form.select :year,
                         [Date.current.year - 1, Date.current.year, Date.current.year + 1],
                         {},
-                        { id: :picture_year, class: 'custom-select' } %>
+                        { class: 'custom-select' } %>
       </div>
 
     </div>

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -52,4 +52,7 @@ Rails.application.configure do
   # Use an evented file watcher to asynchronously detect changes in source code,
   # routes, locales, etc. This feature depends on the listen gem.
   config.file_watcher = ActiveSupport::EventedFileUpdateChecker
+
+  # Enable generation of id-based attributes such as label for
+  config.action_view.form_with_generates_ids = true
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -100,4 +100,7 @@ Rails.application.configure do
 
   # Do not dump schema after migrations.
   config.active_record.dump_schema_after_migration = false
+
+  # Enable generation of id-based attributes such as label for
+  config.action_view.form_with_generates_ids = true
 end

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -39,4 +39,7 @@ Rails.application.configure do
 
   # Raises error for missing translations
   # config.action_view.raise_on_missing_translations = true
+
+  # Enable generation of id-based attributes such as label for
+  config.action_view.form_with_generates_ids = true
 end


### PR DESCRIPTION
Rails 5.1.4 to 5.2 update broke automatic generation of label for attribute, breaking accessibility. Fixing this by forcing a setting.

Also sorting out Safari compatibility by updating grid markup.