### PR TITLE
Make a better guess at the desired month

### DIFF
--- a/app/controllers/pictures_controller.rb
+++ b/app/controllers/pictures_controller.rb
@@ -29,6 +29,9 @@ class PicturesController < ApplicationController
   def new
     @picture = Picture.new
     @picture.user = current_user
+
+    return unless current_user.picture_for_last_month?
+    @picture.month, @picture.year = DateService.increment_last_month
   end
 
   # GET /pictures/1/edit

--- a/app/models/picture.rb
+++ b/app/models/picture.rb
@@ -33,6 +33,13 @@ class Picture < ApplicationRecord
     sort_by_date_user.where(user_id: user.id)
   }
 
+  scope :month_year_for_user, lambda { |month, year, user|
+    where(user_id: user.id)
+      .where(month: month)
+      .where(year: year)
+      .count
+  }
+
   def default_values
     self.month ||= DateService.define_last_month
     self.year ||= DateService.year_for_last_month

--- a/app/models/picture.rb
+++ b/app/models/picture.rb
@@ -33,7 +33,7 @@ class Picture < ApplicationRecord
     sort_by_date_user.where(user_id: user.id)
   }
 
-  scope :month_year_for_user, lambda { |month, year, user|
+  scope :month_year_for_user_count, lambda { |month, year, user|
     where(user_id: user.id)
       .where(month: month)
       .where(year: year)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,3 +1,5 @@
+require 'date_service'
+
 class User < ApplicationRecord
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable and :omniauthable
@@ -20,6 +22,13 @@ class User < ApplicationRecord
   # Custom message for when account disabled
   def inactive_message
     'Account is disabled'
+  end
+
+  # Does this user already have a picture for last month?
+  def picture_for_last_month?
+    month = DateService.define_last_month
+    year = DateService.year_for_last_month
+    Picture.month_year_for_user(month, year, self).positive?
   end
 
   def self.all_active

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -28,7 +28,7 @@ class User < ApplicationRecord
   def picture_for_last_month?
     month = DateService.define_last_month
     year = DateService.year_for_last_month
-    Picture.month_year_for_user(month, year, self).positive?
+    Picture.month_year_for_user_count(month, year, self).positive?
   end
 
   def self.all_active

--- a/lib/date_service.rb
+++ b/lib/date_service.rb
@@ -11,4 +11,18 @@ class DateService
     return Date.current.year unless define_last_month == 12 && Date.current.month == 1
     Date.current.year - 1
   end
+
+  # Take the results of define_last_month and add one, allowing for end of year
+  def self.increment_last_month
+    # If "last month" is December, loop to January and increment year
+    if define_last_month == 12
+      month = 1
+      year = year_for_last_month + 1
+    else
+      month = define_last_month + 1
+      year = year_for_last_month
+    end
+
+    [month, year]
+  end
 end

--- a/test/fixtures/pictures.yml
+++ b/test/fixtures/pictures.yml
@@ -100,3 +100,13 @@ whitespace_to_strip:
   month: 3
   year: 2018
   image: 03-whitespace.jpg
+
+already_has_this_month:
+  user: better_guess_user
+  image_title: Picture for May 2018
+  caption: Caption
+  description: Description
+  alt: Alt
+  month: 5
+  year: 2018
+  image: 05-better.jpg

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -83,3 +83,8 @@ whitespace_user:
   email: whitespace_user@example.com
   fullname: 'White'
   role: 1
+
+better_guess_user:
+  email: better_guess_user@example.com
+  fullname: 'Better'
+  role: 1

--- a/test/integration/pictures_form_test.rb
+++ b/test/integration/pictures_form_test.rb
@@ -34,4 +34,21 @@ class PicturesFormTest < ActionDispatch::IntegrationTest
     assert page.has_content?('Extra information'), 'Words should be visible'
     assert page.has_content?('You can probably ignore these fields'), 'With js disabled, words should be visible'
   end
+
+  test 'correct month is selected' do
+    # Sign in as user with picture
+    sign_out @user
+    sign_in users(:better_guess_user)
+    disable_javascript
+
+    # User has a picture for May so month should bump to June
+    travel_to Time.new(2018, 5, 25)
+    visit new_picture_path
+    assert page.has_select?('picture_month', selected: 'June')
+
+    # User does not have a picture for July and so July should be selected
+    travel_to Time.new(2018, 7, 25)
+    visit new_picture_path
+    assert page.has_select?('picture_month', selected: 'July')
+  end
 end

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -48,4 +48,16 @@ class UserTest < ActiveSupport::TestCase
 
     assert_equal all_active_users.count, User.all_active.count
   end
+
+  test 'user has picture for this month' do
+    user = users(:better_guess_user)
+
+    # User should not have a picture for July
+    travel_to Time.new(2018, 7, 25)
+    refute user.picture_for_last_month?, 'User should not have a picture for July'
+
+    # User should have a picture for May
+    travel_to Time.new(2018, 5, 25)
+    assert user.picture_for_last_month?, 'User should have a picture for May'
+  end
 end

--- a/test/services/date_service_test.rb
+++ b/test/services/date_service_test.rb
@@ -37,4 +37,32 @@ class DateServiceTest < ActiveSupport::TestCase
     travel_to Time.new(2017, 12, 25)
     assert_equal 2017, DateService.year_for_last_month
   end
+
+  test 'month and year when incrementing last month from late May 2018' do
+    travel_to Time.new(2018, 5, 25)
+    month, year = DateService.increment_last_month
+    assert_equal 6, month, 'Month should be June'
+    assert_equal 2018, year, 'Year should be 2018'
+  end
+
+  test 'month and year when incrementing last month from early May 2018' do
+    travel_to Time.new(2018, 5, 5)
+    month, year = DateService.increment_last_month
+    assert_equal 5, month, 'Month should be May'
+    assert_equal 2018, year, 'Year should be 2018'
+  end
+
+  test 'month and year when incrementing last month in early Jan 2018' do
+    travel_to Time.new(2018, 1, 5)
+    month, year = DateService.increment_last_month
+    assert_equal 1, month, 'Month should be January'
+    assert_equal 2018, year, 'Year should be 2018'
+  end
+
+  test 'month and year when incrementing last month in late Dec 2017' do
+    travel_to Time.new(2017, 12, 25)
+    month, year = DateService.increment_last_month
+    assert_equal 1, month, 'Month should be January'
+    assert_equal 2018, year, 'Year should be 2018'
+  end
 end


### PR DESCRIPTION
If a photographer tries adds a photograph too soon, they will no longer double-add for the "last month". If a picture for "last month" is already added it will jump the month on one.