### PR TITLE
Update image filename generation to support forename surname

### DIFF
--- a/app/models/picture.rb
+++ b/app/models/picture.rb
@@ -46,8 +46,11 @@ class Picture < ApplicationRecord
   end
 
   def populate_image_file(extension = 'jpg')
-    # delete method is just in case
-    person_name = user.fullname.gsub(' and ', '-').delete(' ').downcase
+    # "X and Y" to "x-y", "A B" to "a_b"
+    person_name = user.fullname
+                      .gsub(' and ', '-')
+                      .tr(' ', '_')
+                      .downcase
     self.image = "#{month.to_s.rjust(2, '0')}-#{person_name}.#{extension}"
   end
 

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -79,6 +79,11 @@ multi_name_user:
   fullname: 'Tom and Jerry'
   role: 1
 
+two_name_user:
+  email: two_name_user@example.com
+  fullname: 'Angry Wiggleforth'
+  role: 1
+
 whitespace_user:
   email: whitespace_user@example.com
   fullname: 'White'

--- a/test/models/picture_test.rb
+++ b/test/models/picture_test.rb
@@ -2,7 +2,7 @@ require 'test_helper'
 
 class PictureTest < ActiveSupport::TestCase
   setup do
-    @placeholder_picture = Picture.placeholder('test one')
+    @placeholder_picture = Picture.placeholder('TestOne')
   end
 
   test 'correct image filename' do
@@ -11,7 +11,7 @@ class PictureTest < ActiveSupport::TestCase
   end
 
   test 'placeholder with invalid user' do
-    pic = Picture.placeholder('invalid user')
+    pic = Picture.placeholder('InvalidUser')
     assert_equal 'Placeholder', pic.image_title, 'Image title should have been Placeholder'
     assert_equal 'Placeholder', pic.caption, 'Image caption should have been Placeholder'
     assert_equal 'Placeholder', pic.description, 'Image description should have been Placeholder'
@@ -52,6 +52,12 @@ OUTPUT
   test 'correct name for image file for multi-named user' do
     pic = Picture.placeholder(users(:multi_name_user).fullname)
     expected_filename = "#{get_month(pic.month)}-tom-jerry.png"
+    assert_equal expected_filename, pic.image, 'Generated filename does not match expected filename'
+  end
+
+  test 'correct name for image file for forename surname user' do
+    pic = Picture.placeholder(users(:two_name_user).fullname)
+    expected_filename = "#{get_month(pic.month)}-angry_wiggleforth.png"
     assert_equal expected_filename, pic.image, 'Generated filename does not match expected filename'
   end
 


### PR DESCRIPTION
This is saved on the image so going back in time will require some data modification.