### PR TITLE
Add content test framework and some tests

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -24,3 +24,11 @@ $(function() {
     $(".hidden").toggle();
   });
 })
+
+// Hide content test details
+$(function() {
+  $(".results-list").hide();
+  $(".results h2").click(function() {
+    $(this).parent().find("ol").toggle();
+  });
+})

--- a/app/assets/stylesheets/_forms.scss
+++ b/app/assets/stylesheets/_forms.scss
@@ -26,3 +26,7 @@ a.lozenge {
     background-color: #97e8aa;
   }
 }
+
+.results {
+  padding: 1em;
+}

--- a/app/controllers/month_controller.rb
+++ b/app/controllers/month_controller.rb
@@ -1,3 +1,5 @@
+require 'content_test_service'
+
 class MonthController < ApplicationController
   before_action :check_admin
 
@@ -8,6 +10,21 @@ class MonthController < ApplicationController
     return unless month =~ /\A\d{1,2}\z/
 
     @pictures = get_pictures(month, year)
+  end
+
+  def test_month_content
+    @test_results = {}
+    month = params[:month]
+    year = get_year(params[:year])
+    return unless month =~ /\A\d{1,2}\z/
+
+    # for each picture run all tests
+    # { 'Photographer' => { 'test 1' => true, 'test 2' => false } }
+
+    pictures = get_pictures(month, year)
+    pictures.each do |picture|
+      @test_results[picture.user] = ContentTestService.run_tests(picture)
+    end
   end
 
   private

--- a/app/views/month/test_month_content.html.erb
+++ b/app/views/month/test_month_content.html.erb
@@ -1,6 +1,7 @@
 <h1>Test results</h1>
 <%- @test_results.each do |photographer, results| -%>
-<div class="<%= results.values.all? ? 'alert-success' : 'alert-danger' -%>">
+<div id="<%= photographer.fullname.downcase.gsub(' ', '-') -%>"
+     class="results <%= results.values.all? ? 'alert-success' : 'alert-danger' -%>">
   <h2><%= photographer.fullname %></h2>
   <ol>
 <%- results.each do |test_name, result| -%>

--- a/app/views/month/test_month_content.html.erb
+++ b/app/views/month/test_month_content.html.erb
@@ -1,10 +1,10 @@
 <h1>Test results</h1>
 <%- @test_results.each do |photographer, results| -%>
-<div>
+<div class="<%= results.values.all? ? 'alert-success' : 'alert-danger' -%>">
   <h2><%= photographer.fullname %></h2>
   <ol>
 <%- results.each do |test_name, result| -%>
-    <li><%= test_name %>: <%= result %></li>
+    <li class="<%= result ? 'alert-success' : 'alert-danger' -%>"><%= test_name %>: <%= result %></li>
 <%- end -%>
   </ol>
 </div>

--- a/app/views/month/test_month_content.html.erb
+++ b/app/views/month/test_month_content.html.erb
@@ -1,0 +1,11 @@
+<h1>Test results</h1>
+<%- @test_results.each do |photographer, results| -%>
+<div>
+  <h2><%= photographer.fullname %></h2>
+  <ol>
+<%- results.each do |test_name, result| -%>
+    <li><%= test_name %>: <%= result %></li>
+<%- end -%>
+  </ol>
+</div>
+<%- end -%>

--- a/app/views/month/test_month_content.html.erb
+++ b/app/views/month/test_month_content.html.erb
@@ -2,8 +2,8 @@
 <%- @test_results.each do |photographer, results| -%>
 <div id="<%= photographer.fullname.downcase.gsub(' ', '-') -%>"
      class="results <%= results.values.all? ? 'alert-success' : 'alert-danger' -%>">
-  <h2><%= photographer.fullname %></h2>
-  <ol>
+  <h2 class="pointer"><%= photographer.fullname %></h2>
+  <ol class="results-list">
 <%- results.each do |test_name, result| -%>
     <li class="<%= result ? 'alert-success' : 'alert-danger' -%>"><%= test_name %>: <%= result %></li>
 <%- end -%>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,4 +9,5 @@ Rails.application.routes.draw do
   resources :pictures
 
   get 'month/:month', to: 'month#show', as: 'month_view'
+  get 'month-content-test/:month', to: 'month#test_month_content', as: 'test_month_content'
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -2,8 +2,8 @@
 # of editing this file, please use the migrations feature of Active Record to
 # incrementally modify your database, and then regenerate this schema definition.
 #
-# This file is the source Rails uses to define your schema when running `rails
-# db:schema:load`. When creating a new database, `rails db:schema:load` tends to
+# This file is the source Rails uses to define your schema when running `bin/rails
+# db:schema:load`. When creating a new database, `bin/rails db:schema:load` tends to
 # be faster and is potentially less error prone than running all of your
 # migrations from scratch. Old migrations may fail to apply correctly if those
 # migrations use external dependencies or application code.

--- a/lib/content_test_service.rb
+++ b/lib/content_test_service.rb
@@ -14,4 +14,12 @@ class ContentTestService
     # Otherwise last character is a .
     false
   end
+
+  def self.ellipsis_are_three_dots(text)
+    # If there are four or more dots together
+    return false if text =~ /\.{4,}/
+
+    # Otherwise all is fine
+    true
+  end
 end

--- a/lib/content_test_service.rb
+++ b/lib/content_test_service.rb
@@ -31,7 +31,11 @@ class ContentTestService
     true
   end
 
-  # def self.ends_with_punctuation(text)
-  #   false
-  # end
+  def self.ends_with_punctuation(text)
+    # If the final character is punctuation
+    return true if text =~ /[[:punct:]]$/
+
+    # Otherwise reject
+    false
+  end
 end

--- a/lib/content_test_service.rb
+++ b/lib/content_test_service.rb
@@ -1,7 +1,12 @@
 class ContentTestService
   def self.run_tests(picture)
     { 'Title has no ending full stop' => no_ending_fullstop(picture.image_title),
-      'Caption has no ending full stop' => no_ending_fullstop(picture.caption) }
+      'Title ellipsis are correct' => ellipsis_are_three_dots(picture.image_title),
+      'Caption has no ending full stop' => no_ending_fullstop(picture.caption),
+      'Caption ellipsis are correct' => ellipsis_are_three_dots(picture.caption),
+      'Description ends with punctuation' => ends_with_punctuation(picture.description),
+      'Description ellipsis are correct' => ellipsis_are_three_dots(picture.description),
+      'Description I is capitlised' => i_is_capitalised(picture.description) }
   end
 
   def self.no_ending_fullstop(text)

--- a/lib/content_test_service.rb
+++ b/lib/content_test_service.rb
@@ -1,0 +1,17 @@
+class ContentTestService
+  def self.run_tests(picture)
+    { 'Title has no ending full stop' => no_ending_fullstop(picture.image_title),
+      'Caption has no ending full stop' => no_ending_fullstop(picture.caption) }
+  end
+
+  def self.no_ending_fullstop(text)
+    # No ending fullstop if last character is not a .
+    return true if text[-1] != '.'
+
+    # If last character is a ., not a fullstop if last 3 characters are ...
+    return true if text[-3, 3] == '...'
+
+    # Otherwise last character is a .
+    false
+  end
+end

--- a/lib/content_test_service.rb
+++ b/lib/content_test_service.rb
@@ -22,4 +22,16 @@ class ContentTestService
     # Otherwise all is fine
     true
   end
+
+  def self.i_is_capitalised(text)
+    # If there is a lower case I at the start or in the middle
+    return false if text =~ /(\A|\s)i\s/
+
+    # Otherwise all is fine
+    true
+  end
+
+  # def self.ends_with_punctuation(text)
+  #   false
+  # end
 end

--- a/test/fixtures/pictures.yml
+++ b/test/fixtures/pictures.yml
@@ -125,7 +125,7 @@ month_view_normal:
   user: month_view_normal_user
   image_title: Normal Picture for August 2018
   caption: Caption
-  description: Description
+  description: Description.
   alt: Alt
   month: 8
   year: 2018

--- a/test/integration/content_test_test.rb
+++ b/test/integration/content_test_test.rb
@@ -1,0 +1,48 @@
+require 'test_helper'
+
+class ContentTestTest < ActionDispatch::IntegrationTest
+  include Devise::Test::IntegrationHelpers
+
+  setup do
+    @user = users(:admin_user)
+    sign_in @user
+  end
+
+  test 'content test shows correct results' do
+    visit test_month_content_path(month: 8, year: 2018)
+
+    # Check correct number of result blocks
+    assert page.find_all('.results').length == 2, 'Incorrect number of result blocks'
+
+    # Admin user picture
+    admin_user_name = pictures(:month_view_admin).user.fullname
+    # Check includes admin pic
+    assert page.has_content?(admin_user_name),
+           'Month view should list admin user pics'
+    assert page.has_css?("##{admin_user_name.downcase.gsub(' ', '-')}.alert-danger"),
+           'Admin pic should fail overall'
+    assert page.find_all("##{admin_user_name.downcase.gsub(' ', '-')} li.alert-success").length == 6,
+           'Admin pic should have mostly successes'
+    assert page.find_all("##{admin_user_name.downcase.gsub(' ', '-')} li.alert-danger").length == 1,
+           'Admin pic should have one specific failure'
+
+    # Normal user picture
+    normal_user_name = pictures(:month_view_normal).user.fullname
+    # Check includes normal pic and omits pic from same user from a different year
+    assert page.find_all("##{normal_user_name.downcase.gsub(' ', '-')}").length == 1,
+           'Month view should list normal user pics from this year and not others'
+    assert page.has_css?("##{normal_user_name.downcase.gsub(' ', '-')}.alert-success"),
+           'Normal user pic should pass overall'
+    assert page.find_all("##{normal_user_name.downcase.gsub(' ', '-')} li.alert-success").length == 7,
+           'Normal pic should have all successes'
+    assert page.find_all("##{normal_user_name.downcase.gsub(' ', '-')} li.alert-danger").length.zero?,
+           'Normal pic should have no failures'
+
+    # Check is omitting a disabled user pic
+    refute page.has_content?(pictures(:month_view_disabled).user.fullname),
+           'Month view should not list pics for disabled users'
+
+    # Check no placeholder images
+    refute page.has_content?('Placeholder'), 'Page should not contain placeholder entries'
+  end
+end

--- a/test/integration/content_test_test.rb
+++ b/test/integration/content_test_test.rb
@@ -9,6 +9,7 @@ class ContentTestTest < ActionDispatch::IntegrationTest
   end
 
   test 'content test shows correct results' do
+    disable_javascript
     visit test_month_content_path(month: 8, year: 2018)
 
     # Check correct number of result blocks

--- a/test/services/content_test_service_test.rb
+++ b/test/services/content_test_service_test.rb
@@ -72,21 +72,21 @@ class ContentTestServiceTest < ActiveSupport::TestCase
     assert_not(ContentTestService.i_is_capitalised(text), 'Should reject i in the middle of the phrase')
   end
 
-  # test 'ends_with_punctuation accepts when ends with punctuation' do
-  #   text = 'here are some words.'
-  #   assert(ContentTestService.ends_with_punctuation(text), 'Should accept when ending punctuation')
+  test 'ends_with_punctuation accepts when ends with punctuation' do
+    text = 'here are some words.'
+    assert(ContentTestService.ends_with_punctuation(text), 'Should accept when ending punctuation')
 
-  #   text = 'here are some words?'
-  #   assert(ContentTestService.ends_with_punctuation(text), 'Should accept when ending punctuation')
+    text = 'here are some words?'
+    assert(ContentTestService.ends_with_punctuation(text), 'Should accept when ending punctuation')
 
-  #   text = 'here are some words!'
-  #   assert(ContentTestService.ends_with_punctuation(text), 'Should accept when ending punctuation')
-  # end
+    text = 'here are some words!'
+    assert(ContentTestService.ends_with_punctuation(text), 'Should accept when ending punctuation')
+  end
 
-  # test 'ends_with_punctuation rejects when no ending punctuation' do
-  #   text = 'here are some words'
-  #   assert_not(ContentTestService.ends_with_punctuation(text), 'Should reject when no ending punctuation')
-  # end
+  test 'ends_with_punctuation rejects when no ending punctuation' do
+    text = 'here are some words'
+    assert_not(ContentTestService.ends_with_punctuation(text), 'Should reject when no ending punctuation')
+  end
 
   # test 'runner method runs all tests' do
   # end

--- a/test/services/content_test_service_test.rb
+++ b/test/services/content_test_service_test.rb
@@ -1,0 +1,33 @@
+require 'test_helper'
+require 'content_test_service'
+
+# Test ContentTestService
+class ContentTestServiceTest < ActiveSupport::TestCase
+  test 'finds an ending fullstop' do
+    text = 'Words.'
+    assert_not(ContentTestService.no_ending_fullstop(text), 'Should reject trailing fullstop')
+  end
+
+  test 'does not confuse an ellipsis' do
+    text = 'Words...'
+    assert(ContentTestService.no_ending_fullstop(text), 'Should accept trailing ellipsis')
+  end
+
+  test 'passes no trailing punctuation' do
+    text = 'Words'
+    assert(ContentTestService.no_ending_fullstop(text), 'Should accept no trailing punctuation')
+  end
+
+  test 'passes training exclamation mark' do
+    text = 'Words!'
+    assert(ContentTestService.no_ending_fullstop(text), 'Should accept trailing exclamation mark')
+  end
+
+  test 'passes training question mark' do
+    text = 'Words?'
+    assert(ContentTestService.no_ending_fullstop(text), 'Should accept trailing question mark')
+  end
+
+  # test 'runner method runs all tests' do
+  # end
+end

--- a/test/services/content_test_service_test.rb
+++ b/test/services/content_test_service_test.rb
@@ -56,6 +56,38 @@ class ContentTestServiceTest < ActiveSupport::TestCase
     assert_not(ContentTestService.ellipsis_are_three_dots(text), 'Should reject more than four dots')
   end
 
+  test 'i_is_capitalised accepts I when capitalised' do
+    text = 'I at the start'
+    assert(ContentTestService.i_is_capitalised(text), 'Should accept capitalised I at the start of the phrase')
+
+    text = 'Placing I in the middle'
+    assert(ContentTestService.i_is_capitalised(text), 'Should accept capitalised I in the middle of the phrase')
+  end
+
+  test 'i_is_capitalised rejects i when not capitalised' do
+    text = 'i at the start'
+    assert_not(ContentTestService.i_is_capitalised(text), 'Should reject i at the start of the phrase')
+
+    text = 'placing i in the middle'
+    assert_not(ContentTestService.i_is_capitalised(text), 'Should reject i in the middle of the phrase')
+  end
+
+  # test 'ends_with_punctuation accepts when ends with punctuation' do
+  #   text = 'here are some words.'
+  #   assert(ContentTestService.ends_with_punctuation(text), 'Should accept when ending punctuation')
+
+  #   text = 'here are some words?'
+  #   assert(ContentTestService.ends_with_punctuation(text), 'Should accept when ending punctuation')
+
+  #   text = 'here are some words!'
+  #   assert(ContentTestService.ends_with_punctuation(text), 'Should accept when ending punctuation')
+  # end
+
+  # test 'ends_with_punctuation rejects when no ending punctuation' do
+  #   text = 'here are some words'
+  #   assert_not(ContentTestService.ends_with_punctuation(text), 'Should reject when no ending punctuation')
+  # end
+
   # test 'runner method runs all tests' do
   # end
 end

--- a/test/services/content_test_service_test.rb
+++ b/test/services/content_test_service_test.rb
@@ -88,6 +88,12 @@ class ContentTestServiceTest < ActiveSupport::TestCase
     assert_not(ContentTestService.ends_with_punctuation(text), 'Should reject when no ending punctuation')
   end
 
-  # test 'runner method runs all tests' do
-  # end
+  test 'runner method runs all tests and they pass' do
+    picture = Picture.new(image_title: 'Title',
+                          caption:     'Caption',
+                          description: 'Description.')
+    results = ContentTestService.run_tests(picture)
+    assert(results.keys.count == 7, 'Incorrect number of tests')
+    assert(results.all?, 'All tests should have passed')
+  end
 end

--- a/test/services/content_test_service_test.rb
+++ b/test/services/content_test_service_test.rb
@@ -3,29 +3,57 @@ require 'content_test_service'
 
 # Test ContentTestService
 class ContentTestServiceTest < ActiveSupport::TestCase
-  test 'finds an ending fullstop' do
+  test 'no_ending_fullstop finds an ending full stop' do
     text = 'Words.'
-    assert_not(ContentTestService.no_ending_fullstop(text), 'Should reject trailing fullstop')
+    assert_not(ContentTestService.no_ending_fullstop(text), 'Should reject trailing full stop')
   end
 
-  test 'does not confuse an ellipsis' do
+  test 'no_ending_fullstop does not confuse an ellipsis' do
     text = 'Words...'
     assert(ContentTestService.no_ending_fullstop(text), 'Should accept trailing ellipsis')
   end
 
-  test 'passes no trailing punctuation' do
+  test 'no_ending_fullstop passes no trailing punctuation' do
     text = 'Words'
     assert(ContentTestService.no_ending_fullstop(text), 'Should accept no trailing punctuation')
   end
 
-  test 'passes training exclamation mark' do
+  test 'no_ending_fullstop passes training exclamation mark' do
     text = 'Words!'
     assert(ContentTestService.no_ending_fullstop(text), 'Should accept trailing exclamation mark')
   end
 
-  test 'passes training question mark' do
+  test 'no_ending_fullstop passes training question mark' do
     text = 'Words?'
     assert(ContentTestService.no_ending_fullstop(text), 'Should accept trailing question mark')
+  end
+
+  test 'ellipsis_are_three_dots passes a trailing three dot ellipsis' do
+    text = 'So...'
+    assert(ContentTestService.ellipsis_are_three_dots(text), 'Should accept three dots')
+  end
+
+  test 'ellipsis_are_three_dots passes a three dot ellipsis in the middle of the phrase' do
+    text = 'So... how does this work?'
+    assert(ContentTestService.ellipsis_are_three_dots(text), 'Should accept three dots')
+  end
+
+  test 'ellipsis_are_three_dots is not confused by a trailing full stop' do
+    text = 'Words.'
+    assert(ContentTestService.ellipsis_are_three_dots(text), 'Should ignore trailing full stop')
+  end
+
+  test 'ellipsis_are_three_dots is not confused by a full stop mid-phrase' do
+    text = 'Words. Here goes!'
+    assert(ContentTestService.ellipsis_are_three_dots(text), 'Should ignore mid-phrase full stop')
+  end
+
+  test 'ellipsis_are_three_dots rejects more than three dots' do
+    text = 'Words.... Here goes!'
+    assert_not(ContentTestService.ellipsis_are_three_dots(text), 'Should reject four dots')
+
+    text = 'Words...... Here goes!'
+    assert_not(ContentTestService.ellipsis_are_three_dots(text), 'Should reject more than four dots')
   end
 
   # test 'runner method runs all tests' do


### PR DESCRIPTION
Add content test framework to check for the most common content style errors and highlight for edit. This will smooth the monthly upload process, by removing some of the edit / correction cycles.

Extensible, so as further common errors are identified they can be added in.