### PR TITLE
Increase speed of index page for admins

### DIFF
--- a/.github/config/rubocop_linter_action.yml
+++ b/.github/config/rubocop_linter_action.yml
@@ -1,3 +1,4 @@
 versions:
   - rubocop
+  - rubocop-capybara
   - rubocop-rails

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,4 +1,6 @@
-require: rubocop-rails
+require:
+  - rubocop-capybara
+  - rubocop-rails
 
 AllCops:
   NewCops: enable

--- a/Gemfile
+++ b/Gemfile
@@ -29,6 +29,7 @@ group :development, :test do
   gem 'apparition', github: 'twalpole/apparition'
   gem 'capybara'
   gem 'rubocop'
+  gem 'rubocop-capybara', require: false
   gem 'rubocop-rails', require: false
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -252,6 +252,8 @@ GEM
       unicode-display_width (>= 2.4.0, < 3.0)
     rubocop-ast (1.32.3)
       parser (>= 3.3.1.0)
+    rubocop-capybara (2.21.0)
+      rubocop (~> 1.41)
     rubocop-rails (2.26.2)
       activesupport (>= 4.2.0)
       rack (>= 1.1)
@@ -320,6 +322,7 @@ DEPENDENCIES
   puma
   rails (~> 7)
   rubocop
+  rubocop-capybara
   rubocop-rails
   sass-rails
   spring

--- a/app/controllers/pictures_controller.rb
+++ b/app/controllers/pictures_controller.rb
@@ -109,7 +109,8 @@ class PicturesController < ApplicationController
   end
 
   def set_picture_list
-    current_user.admin? ? Picture.sort_by_date_user : Picture.sorted_filtered_for_user(current_user)
+    year = params[:year] || Date.current.year
+    current_user.admin? ? Picture.sorted_filtered_for_admin(year) : Picture.sorted_filtered_for_user(current_user)
   end
 
   # Never trust parameters from the scary internet, only allow the accepted list through.

--- a/app/models/picture.rb
+++ b/app/models/picture.rb
@@ -28,6 +28,10 @@ class Picture < ApplicationRecord
       .order('users.fullname asc')
   }
 
+  scope :sorted_filtered_for_admin, lambda { |year|
+    sort_by_date_user.where(year: year)
+  }
+
   scope :sorted_filtered_for_user, lambda { |user|
     sort_by_date_user.where(user_id: user.id)
   }

--- a/test/integration/picture_submit_test.rb
+++ b/test/integration/picture_submit_test.rb
@@ -50,7 +50,7 @@ class PictureSubmitTest < ActionDispatch::IntegrationTest
     new_title = "New title for #{user.fullname.downcase}"
 
     # Find the right picture and click to edit screen
-    visit pictures_path
+    visit pictures_path(year: picture.year)
     page.first(:css, "a[href=\"#{edit_picture_path(id: picture.id)}\"]").click
     assert_equal edit_picture_path(id: picture.id), page.current_path, 'We are on the wrong page'
 

--- a/test/integration/pictures_index_test.rb
+++ b/test/integration/pictures_index_test.rb
@@ -43,14 +43,14 @@ class PicturesIndexTest < ActionDispatch::IntegrationTest
 
     # Check picture belonging to different user is linked from the index page
     visit pictures_path
-    photographer_with_picture_element = find '#will-have-picture-no-admin'
+    photographer_with_picture_element = find_by_id 'will-have-picture-no-admin'
     assert_equal 'a', photographer_with_picture_element.tag_name, 'Incorrect type of element found'
 
     photographer_with_picture_uri = URI.parse(photographer_with_picture_element['href'])
     assert_equal edit_picture_path(pic), photographer_with_picture_uri.path, 'Incorrect link target'
 
     # Check lozenge for different user does not link
-    photographer_without_picture_element = find '#will-not-have-picture-no-admin-logged-out'
+    photographer_without_picture_element = find_by_id 'will-not-have-picture-no-admin-logged-out'
     assert_equal 'p', photographer_without_picture_element.tag_name, 'Incorrect type of element found'
   end
 
@@ -60,14 +60,14 @@ class PicturesIndexTest < ActionDispatch::IntegrationTest
 
     # Check add picture page for same user is linked from the index page
     visit pictures_path
-    photographer_without_picture_element = find '#will-not-have-picture-no-admin'
+    photographer_without_picture_element = find_by_id 'will-not-have-picture-no-admin'
     assert_equal 'a', photographer_without_picture_element.tag_name, 'Incorrect type of element found'
 
     photographer_without_picture_uri = URI.parse(photographer_without_picture_element['href'])
     assert_equal new_picture_path, photographer_without_picture_uri.path, 'Incorrect link target'
 
     # Check lozenge for different user does not link
-    photographer_without_picture_element = find '#will-not-have-picture-no-admin-logged-out'
+    photographer_without_picture_element = find_by_id 'will-not-have-picture-no-admin-logged-out'
     assert_equal 'p', photographer_without_picture_element.tag_name, 'Incorrect type of element found'
   end
 
@@ -85,7 +85,7 @@ class PicturesIndexTest < ActionDispatch::IntegrationTest
 
     # Check picture belonging to different user is linked from the index page
     visit pictures_path
-    photographer_with_picture_element = find '#will-have-picture-admin'
+    photographer_with_picture_element = find_by_id 'will-have-picture-admin'
     assert_equal 'a', photographer_with_picture_element.tag_name, 'Incorrect type of element found'
 
     photographer_with_picture_uri = URI.parse(photographer_with_picture_element['href'])
@@ -98,7 +98,7 @@ class PicturesIndexTest < ActionDispatch::IntegrationTest
 
     # Check add picture page for different user is linked from the index page
     visit pictures_path
-    photographer_without_picture_element = find '#will-not-have-picture-admin'
+    photographer_without_picture_element = find_by_id 'will-not-have-picture-admin'
     assert_equal 'a', photographer_without_picture_element.tag_name, 'Incorrect type of element found'
 
     photographer_without_picture_uri = URI.parse(photographer_without_picture_element['href'])

--- a/test/integration/pictures_index_test.rb
+++ b/test/integration/pictures_index_test.rb
@@ -23,8 +23,8 @@ class PicturesIndexTest < ActionDispatch::IntegrationTest
   end
 
   test 'index page only contains images belonging to user' do
-    get pictures_url
-    displayed_pictures = css_select 'tbody > tr'
+    visit pictures_path
+    displayed_pictures = page.all 'tbody > tr'
     owned_pictures = @user.pictures
     assert_equal owned_pictures.count, displayed_pictures.count
   end
@@ -105,11 +105,19 @@ class PicturesIndexTest < ActionDispatch::IntegrationTest
     assert_equal new_picture_path, photographer_without_picture_uri.path, 'Incorrect link target'
   end
 
-  test 'index page lists all images for admin' do
+  test 'index page lists all images from this year for admin' do
     sign_out @user
     sign_in users(:admin_user)
-    get pictures_url
-    displayed_pictures = css_select 'tbody > tr'
-    assert_equal Picture.count, displayed_pictures.count
+    visit pictures_path
+    displayed_pictures = page.all 'tbody > tr'
+    assert_equal Picture.where(year: Date.current.year).count, displayed_pictures.count
+  end
+
+  test 'index page lists all images from specified year for admin' do
+    sign_out @user
+    sign_in users(:admin_user)
+    visit pictures_path(year: 2017)
+    displayed_pictures = page.all 'tbody > tr'
+    assert_equal Picture.where(year: 2017).count, displayed_pictures.count
   end
 end


### PR DESCRIPTION
Should not affect normal user experience.

Also add in Capybara rubocop linting and correct syntax.