### PR TITLE
Fix N+1 query on homepage pictures table

### DIFF
--- a/app/models/picture.rb
+++ b/app/models/picture.rb
@@ -22,7 +22,7 @@ class Picture < ApplicationRecord
   before_save :strip_whitespace
 
   scope :sort_by_date_user, lambda {
-    joins('left join users on pictures.user_id = users.id')
+    eager_load(:user)
       .order(year: :desc)
       .order(month: :desc)
       .order('users.fullname asc')

--- a/app/views/pictures/index.html.erb
+++ b/app/views/pictures/index.html.erb
@@ -8,7 +8,7 @@
 
 <div class="row">
   <div class="col-12">
-    <h2>Added for the last month (<%= @last_month_name %>): <%= @last_month_pictures.count %> / <%= @photographers.count %></h2>
+    <h2>Added for the last month (<%= @last_month_name %>): <%= @last_month_pictures.size %> / <%= @photographers.count %></h2>
   </div>
 
   <%- @photographers.each do |photographer, pic_submitted|


### PR DESCRIPTION
Replace manual joins with eager_load(:user) in sort_by_date_user scope so the user association is populated from the JOIN rather than firing a separate query per picture row. Also use .size instead of .count for last_month_pictures to avoid a redundant COUNT query on already-loaded records.